### PR TITLE
Increase maximum dedicated USB charge current to 2A

### DIFF
--- a/drivers/power/qpnp-smbcharger.c
+++ b/drivers/power/qpnp-smbcharger.c
@@ -456,7 +456,7 @@ module_param_named(
 	int, S_IRUSR | S_IWUSR
 );
 
-static int smbchg_default_hvdcp_icl_ma = 1800;
+static int smbchg_default_hvdcp_icl_ma = 2000;
 module_param_named(
 	default_hvdcp_icl_ma, smbchg_default_hvdcp_icl_ma,
 	int, S_IRUSR | S_IWUSR
@@ -468,7 +468,7 @@ module_param_named(
 	int, S_IRUSR | S_IWUSR
 );
 
-static int smbchg_default_dcp_icl_ma = 1800;
+static int smbchg_default_dcp_icl_ma = 2000;
 module_param_named(
 	default_dcp_icl_ma, smbchg_default_dcp_icl_ma,
 	int, S_IRUSR | S_IWUSR

--- a/drivers/usb/dwc3/dwc3-msm.c
+++ b/drivers/usb/dwc3/dwc3-msm.c
@@ -54,8 +54,8 @@
 #include "debug.h"
 #include "xhci.h"
 
-#define DWC3_IDEV_CHG_MAX 1500
-#define DWC3_HVDCP_CHG_MAX 1800
+#define DWC3_IDEV_CHG_MAX 2000
+#define DWC3_HVDCP_CHG_MAX 2000
 static struct dwc3_msm *_msm_dwc;
 
 /* AHB2PHY register offsets */


### PR DESCRIPTION
Increase maximum charge input current from USB port using dedicated charging ports to 2A. All leeco msm8996 devices support QC3.0 which supports at least 9V 2A HVDCP charging. The USB Type-C port is rated for 3A power so it would be beneficial to use up to 2A current for both 5V and 9V charging. (in reality setting the values to 2000 results in 1870mA - 1960mA output from QC 3.0 chargers which support 9V 2A charging, tested on zl1 with 4 different charges using USB power meter)